### PR TITLE
Fix: 배포시 맵이 나타나지않는 에러 수정

### DIFF
--- a/components/pages/map/KakaoMap.tsx
+++ b/components/pages/map/KakaoMap.tsx
@@ -1,13 +1,13 @@
 import { locationState } from "@/state/location";
 import { locationType } from "@/types/location";
 import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
+import React, { use, useEffect, useState } from "react";
 import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
 import { useRecoilState } from "recoil";
 
 export default function KakaoMap() {
-  const [currentLat, setCurrentLat] = useState<number>(33.5563);
-  const [currentLng, setCurrentLng] = useState<number>(126.79581);
+  const [currentLat, setCurrentLat] = useState<number>(0);
+  const [currentLng, setCurrentLng] = useState<number>(0);
   const [initLoc, setInitLoc] = useState<locationType>({
     latitude: 0,
     longitude: 0,
@@ -19,7 +19,8 @@ export default function KakaoMap() {
   });
 
   const router = useRouter();
-  // console.log("router: ", router);
+
+  console.log("recoil로 넘어온 차 위치 : ", carLocation);
 
   useEffect(() => {
     const getLocation = () => {
@@ -29,11 +30,25 @@ export default function KakaoMap() {
             const time = new Date(position.timestamp);
             setCurrentLat(position.coords.latitude);
             setCurrentLng(position.coords.longitude);
+            if (carLocation.latitude == 0 && carLocation.longitude == 0) {
+              setInitLoc({
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+              });
+            } else {
+              setInitLoc({
+                latitude: carLocation.latitude,
+                longitude: carLocation.longitude,
+              });
+            }
+
             console.log("렌더링됨");
-            // console.log(position);
-            // console.log(`현재시간 : ${time}`);
             // console.log(`현재위도 : ${position.coords.latitude}`);
             // console.log(`현재경도 : ${position.coords.longitude}`);
+            setCarLocation({
+              latitude: 0,
+              longitude: 0,
+            });
           },
           (error) => {
             console.error(error);
@@ -52,33 +67,15 @@ export default function KakaoMap() {
     getLocation();
   }, []);
 
-  useEffect(() => {
-    setInitLoc((loc) => {
-      const tempLoc = { ...loc };
-      if (carLocation.latitude !== 0 && carLocation.longitude !== 0) {
-        (loc.latitude = carLocation.latitude),
-          (loc.longitude = carLocation.longitude);
-      } else {
-        (loc.latitude = currentLat), (loc.longitude = currentLng);
-      }
-      return tempLoc;
-    });
-  }, [currentLat, currentLng]);
-
-  console.log("recoil로 넘어온 차 위치 : ", carLocation);
-
   const centerChangeHandler = (map: kakao.maps.Map) => {
     setCenter({
       lat: map.getCenter().getLat(),
       lng: map.getCenter().getLng(),
     });
-    setCarLocation({
-      latitude: 0,
-      longitude: 0,
-    });
   };
 
-  console.log("init : ", initLoc);
+  // console.log("init : ", initLoc);
+  // console.log("세팅된 현재 위도 : ", currentLat);
   console.log("센터 좌표 :", center);
 
   const overLayClickHandler = () => {};


### PR DESCRIPTION
## ⭐Key Changes

1. 배포 시 map이 나타나지 않는 에러를 수정하였습니다

- `next.config.js` 의 `react strict mode`가 개발시에는 활성화 되어 있지만, 배포시에는 적용되지 않아 생기는 문제였습니다.
- 개발모드에서는 두번 렌더링 되기 때문에, 두번 렌더링 되면서 변하는 값에 `useEffect`의 dependency를 주입하여 맵의 초기 위치를 세팅하여 에러가 발생하였습니다.
- `useEffect`의 dependency를 빈 배열[] 로 주었을때 초기값을 세팅하게 함으로써 처음 한번 렌더링 될때 map의 포커스를 잡을 수 있도록 에러 수정하였습니다.
- **strict mode가 활성화 될때나 안될때나 실행 가능하도록 만들어 두었으니 개발하실 때는 strict mode=true로 설정하시고 개발 하시면 됩니다! ( 예상못한 에러 방지 )**

## 📌 issue

close #35 

## To Reviewers

속이 시원합니다 ...ㅎㅎ 

## Next move

빌리타존 표시
